### PR TITLE
chore: add Copilot responder Action (automations/copilot-respond)

### DIFF
--- a/.github/scripts/respond.js
+++ b/.github/scripts/respond.js
@@ -1,0 +1,83 @@
+// Minimal responder: reads comment, calls an LLM, posts a reply.
+// Node 18+ has fetch built-in.
+import fs from 'fs';
+
+const eventPath = process.env.GITHUB_EVENT_PATH;
+if (!eventPath) {
+  console.error('GITHUB_EVENT_PATH not set'); process.exit(1);
+}
+const event = JSON.parse(fs.readFileSync(eventPath, 'utf8'));
+const comment = event.comment?.body || '';
+const author = event.comment?.user?.login || '';
+const repo = process.env.GITHUB_REPOSITORY; // owner/repo
+const [owner, repoName] = repo.split('/');
+
+if (!comment.includes('@copilot')) {
+  console.log('No @copilot mention; exiting.'); process.exit(0);
+}
+// Avoid responding to bot comments or ourselves
+if (author === 'github-actions[bot]' || author === 'copilot' || author === 'Copilot') {
+  console.log('Comment authored by bot; exiting.'); process.exit(0);
+}
+
+// Build prompt. Adjust for more context if desired.
+const prompt = `A reviewer on GitHub wrote:\n\n${comment}\n\nPlease write a polite, concise reply addressing the points raised and suggest next steps.`;
+
+async function callLLM(promptText) {
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) throw new Error('OPENAI_API_KEY missing');
+  const res = await fetch('https://api.openai.com/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${apiKey}`
+    },
+    body: JSON.stringify({
+      model: 'gpt-4o-mini', // replace with your model if needed
+      messages: [{ role: 'user', content: promptText }],
+      max_tokens: 500
+    })
+  });
+  if (!res.ok) {
+    const txt = await res.text();
+    throw new Error('LLM error: ' + txt);
+  }
+  const data = await res.json();
+  return data.choices?.[0]?.message?.content?.trim() ?? '';
+}
+
+async function postReply(body) {
+  // Prefer a BOT_TOKEN secret (machine user) for clear provenance; fallback to GITHUB_TOKEN
+  const token = process.env.BOT_TOKEN || process.env.GITHUB_TOKEN;
+  if (!token) throw new Error('No token available to post reply');
+  const issueNumber = event.issue?.number || event.pull_request?.number;
+  if (!issueNumber) throw new Error('No issue/PR number in event payload');
+
+  const url = `https://api.github.com/repos/${owner}/${repoName}/issues/${issueNumber}/comments`;
+  const resp = await fetch(url, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+      Accept: 'application/vnd.github.v3+json'
+    },
+    body: JSON.stringify({ body })
+  });
+  if (!resp.ok) {
+    const txt = await resp.text();
+    throw new Error('GitHub post failed: ' + txt);
+  }
+  console.log('Posted reply.');
+}
+
+(async () => {
+  try {
+    const reply = await callLLM(prompt);
+    // include a clear provenance header as requested
+    const final = `Copilot Response:\n\n${reply}`;
+    await postReply(final);
+  } catch (e) {
+    console.error('Error:', e);
+    process.exit(1);
+  }
+})();

--- a/.github/workflows/copilot-respond.yml
+++ b/.github/workflows/copilot-respond.yml
@@ -1,0 +1,27 @@
+name: Copilot respond to mentions
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  respond:
+    runs-on: ubuntu-latest
+    # Only run when the comment body contains the literal "@copilot"
+    if: contains(github.event.comment.body, '@copilot')
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+      - name: Run responder
+        env:
+          GITHUB_EVENT_PATH: ${{ github.event_path }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          # Use BOT_TOKEN if you want comments from a bot account; otherwise GITHUB_TOKEN (actions bot)
+          BOT_TOKEN: ${{ secrets.BOT_TOKEN }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+        run: node .github/scripts/respond.js

--- a/COPILOT-RESPONDER-README.md
+++ b/COPILOT-RESPONDER-README.md
@@ -1,0 +1,21 @@
+# Copilot responder automation
+
+This branch adds a minimal GitHub Action that responds to comments mentioning `@copilot` by calling an LLM and posting the generated reply back to the issue or PR.
+
+How it works
+- The workflow .github/workflows/copilot-respond.yml runs on new issue comments.
+- If the comment body contains the literal `@copilot`, the Action runs .github/scripts/respond.js.
+- The script sends the comment text to an LLM (OpenAI in this example) and posts the generated reply as a new issue/PR comment.
+- Each generated reply is prefixed with the line `Copilot Response:` for provenance.
+
+Secrets
+- OPENAI_API_KEY: required. Add this to repository Secrets with a key that can call your chosen LLM.
+- (Optional) BOT_TOKEN: a machine user Personal Access Token (repo scope). If present, the Action will post replies as that account. If omitted, replies are posted by the GitHub Actions bot (github-actions[bot]).
+
+Safety notes
+- The script ignores comments authored by common bot accounts to avoid loops. You may want to extend this allow/deny list.
+- Only trigger on an explicit mention `@copilot` to reduce accidental runs.
+
+Usage
+1. Add the OPENAI_API_KEY secret (and BOT_TOKEN if you want a distinct identity).
+2. Merge the PR and the Action will be active. When you comment `@copilot` in a PR or issue, the Action will reply.


### PR DESCRIPTION
Relates to https://github.com/vertical-cloud-lab/powder-doser/pull/76

This PR adds a minimal GitHub Action and script that responds to issue/PR comments containing "@copilot".

Behavior:

When a comment includes "@copilot", the action calls an LLM with the comment text and posts the generated reply as a new issue/PR comment.
Each reply is prefixed with "Copilot Response:" for provenance.
Secrets required: OPENAI_API_KEY (required), BOT_TOKEN (optional).
Notes: replies are posted by github-actions[bot] unless BOT_TOKEN is configured.